### PR TITLE
Fix patient search by custom fields for multiple fields

### DIFF
--- a/src/Ultimed/Requests/PatientSearchByCustomFields.php
+++ b/src/Ultimed/Requests/PatientSearchByCustomFields.php
@@ -8,10 +8,11 @@ class PatientSearchByCustomFields extends ApiRequest
 
     public function __construct($customFields)
     {
-        $uri = new Uri('/v1/patients');
-        foreach ($customFields as $fieldName => $value) {
-          $uri = $uri->withQuery("filter[$fieldName]=$value");
-        }
+        $query = implode('&', array_map(function($fieldName, $value) {
+            return "filter[$fieldName]=$value";
+        }, array_keys($customFields), $customFields));
+
+        $uri = (new Uri('/v1/patients'))->withQuery($query);
 
         parent::__construct('GET', $uri);
     }


### PR DESCRIPTION
Before, it would only send the last field/value pair requested. Now it
combines all given field/value pairs.