### PR TITLE
Update readme to fix 404 ComposerTransportException

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Create a `composer.json` file in the root directory:
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/lan0/ultimed-integration"
+            "url": "https://github.com/lan0/ultimed-integration",
+            "no-api": true
         }
     ]
 }


### PR DESCRIPTION
Composer require throws an exception with the provided instruction in the readme:

![image](https://user-images.githubusercontent.com/8089223/87396899-d2857180-c5b3-11ea-9520-d4698f813b83.png)

Adding the `"no-api": true` prop seems to fix this
