### PR TITLE
Pslugs/fix guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ultimed/integration",
     "description": "Integration Kit for Ultimed",
     "require": {
-        "guzzlehttp/psr7": "^1.2",
+        "guzzlehttp/psr7": "^1.2|^2.0",
         "guzzlehttp/guzzle": "^6.1",
         "nesbot/carbon": "^2.17"
     },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Integration Kit for Ultimed",
     "require": {
         "guzzlehttp/psr7": "^1.2|^2.0",
-        "guzzlehttp/guzzle": "^6.1",
+        "guzzlehttp/guzzle": "^6.1|^7.0",
         "nesbot/carbon": "^2.17"
     },
     "autoload": {

--- a/src/Ultimed/ApiClient.php
+++ b/src/Ultimed/ApiClient.php
@@ -38,7 +38,7 @@ class ApiClient extends Client
         $this->accessToken = $accessToken;
     }
 
-    public function send(RequestInterface $request, array $options = [])
+    public function send(RequestInterface $request, array $options = []): ResponseInterface
     {
         $request = $this->prepareRequest($request);
 

--- a/src/Ultimed/Requests/IncludesOAuthAccessToken.php
+++ b/src/Ultimed/Requests/IncludesOAuthAccessToken.php
@@ -12,7 +12,7 @@ trait IncludesOAuthAccessToken
         $this->accessToken = $accessToken;
     }
 
-    public function getHeaders()
+    public function getHeaders(): array
     {
         $headers = parent::getHeaders();
         if ($this->hasValidAccessToken()) {
@@ -22,7 +22,7 @@ trait IncludesOAuthAccessToken
         return $headers;
     }
 
-    public function hasHeader($name)
+    public function hasHeader($name): bool
     {
         if (strtolower($name) === 'authorization') {
             return $this->hasValidAccessToken();
@@ -31,7 +31,7 @@ trait IncludesOAuthAccessToken
         return parent::hasHeader($name);
     }
 
-    public function getHeader($name)
+    public function getHeader($name): array
     {
         $headers = parent::getHeader($name);
 

--- a/src/Ultimed/Requests/IncludesOAuthClientCredentials.php
+++ b/src/Ultimed/Requests/IncludesOAuthClientCredentials.php
@@ -35,6 +35,6 @@ trait IncludesOAuthClientCredentials
         $data = json_decode($stream->getContents(), true);
         $data = array_merge($this->credentials->toArray(), $data);
         $json = json_encode($data);
-        return $this->bodyStream = Psr7\stream_for($json);
+        return $this->bodyStream = Psr7\Utils::streamFor($json);
     }
 }

--- a/src/Ultimed/Requests/IncludesOAuthClientCredentials.php
+++ b/src/Ultimed/Requests/IncludesOAuthClientCredentials.php
@@ -1,6 +1,7 @@
 <?php namespace Ultimed\Requests;
 
 use GuzzleHttp\Psr7;
+use Psr\Http\Message\StreamInterface;
 use Ultimed\OAuth\ClientCredentials;
 
 trait IncludesOAuthClientCredentials
@@ -13,7 +14,13 @@ trait IncludesOAuthClientCredentials
         $this->credentials = $credentials;
     }
 
-    public function getBody()
+    /**
+     * override for classes that implement Psr\Http\Message\ResponseInterface
+     *
+     * @see Psr\Http\Message\ResponseInterface
+     * @see GuzzleHttp\Psr7\MessageTrait::getBody()
+     */
+    public function getBody(): StreamInterface
     {
         if ($this->bodyStream !== null) {
             return $this->bodyStream;

--- a/src/Ultimed/Responses/ApiResponse.php
+++ b/src/Ultimed/Responses/ApiResponse.php
@@ -1,8 +1,9 @@
 <?php namespace Ultimed\Responses;
 
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Psr7\Response;
 
 class ApiResponse implements ResponseInterface
 {
@@ -38,72 +39,72 @@ class ApiResponse implements ResponseInterface
     // Delegated Methods
     //
 
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->response->getStatusCode();
     }
 
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus($code, $reasonPhrase = ''): ResponseInterface
     {
         return $this->response->withStatus($code, $reasonPhrase);
     }
 
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->response->getReasonPhrase();
     }
 
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->response->getProtocolVersion();
     }
 
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version): MessageInterface
     {
         return $this->response->withProtocolVersion($version);
     }
 
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->response->getHeaders();
     }
 
-    public function hasHeader($name)
+    public function hasHeader($name): bool
     {
         return $this->response->hasHeader($name);
     }
 
-    public function getHeader($name)
+    public function getHeader($name): array
     {
         return $this->response->getHeader($name);
     }
 
-    public function getHeaderLine($name)
+    public function getHeaderLine($name): string
     {
         return $this->response->getHeaderLine($name);
     }
 
-    public function withHeader($name, $value)
+    public function withHeader($name, $value): MessageInterface
     {
         return $this->response->withHeader($name, $value);
     }
 
-    public function withAddedHeader($name, $value)
+    public function withAddedHeader($name, $value): MessageInterface
     {
         return $this->response->withAddedHeader($name, $value);
     }
 
-    public function withoutHeader($name)
+    public function withoutHeader($name): MessageInterface
     {
         return $this->response->withoutHeader($name);
     }
 
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         return $this->response->getBody();
     }
 
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         return $this->response->withBody($body);
     }


### PR DESCRIPTION
Tried 0.9.4 with this PR https://github.com/foos-bar/ultimed-hub/pull/97, but got the following output when running phpunit:
```
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

...
Fatal error: Declaration of Ultimed\Requests\IncludesOAuthClientCredentials::getBody() must be compatible with GuzzleHttp\Psr7\Request::getBody(): Psr\Http\Message\StreamInterface in /Users/peter/code/ultimed-hub/vendor/ultimed/integration/src/Ultimed/Requests/Authentication.php on line 16

Fatal error: Uncaught Illuminate\Contracts\Container\BindingResolutionException: Target [Illuminate\Contracts\Debug\ExceptionHandler] is not instantiable. in /Users/peter/code/ultimed-hub/vendor/laravel/framework/src/Illuminate/Container/Container.php:1089
Stack trace:
#0 /Users/peter/code/ultimed-hub/vendor/laravel/framework/src/Illuminate/Container/Container.php(886): Illuminate\Container\Container->notInstantiable('Illuminate\\Cont...')
#1 /Users/peter/code/ultimed-hub/vendor/laravel/framework/src/Illuminate/Container/Container.php(758): Illuminate\Container\Container->build('Illuminate\\Cont...')
#2 /Users/peter/code/ultimed-hub/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(853): Illuminate\Container\Container->resolve('Illuminate\\Cont...', Array, true)
#3 /Users/peter/code/ultimed-hub/vendor/laravel/framework/src/Illuminate/Container/Container.php(694): Illuminate\Foundation\Application->resolve('Illuminate\\Cont...', Array)
#4 /Users/peter/code/ultimed-hub/vendor/laravel/framework/src/Illuminat in /Users/peter/code/ultimed-hub/vendor/laravel/framework/src/Illuminate/Container/Container.php on line 1089
```

I assume guzzle added function return types in version 7, so our functions were not compatible anymore with it.

Noticed a call to a function that was moved as well, with a replacement here: https://github.com/guzzle/guzzle/issues/2824#issuecomment-883971577