### PR TITLE
Do not consume HTTP stream when parsing json

### DIFF
--- a/src/Ultimed/Responses/ApiResponse.php
+++ b/src/Ultimed/Responses/ApiResponse.php
@@ -25,7 +25,7 @@ class ApiResponse implements ResponseInterface
 
     public function parseJson()
     {
-        $json = $this->response->getBody()->getContents();
+        $json = (string) $this->response->getBody();
         return json_decode($json, true);
     }
 


### PR DESCRIPTION
With `$this->response->getBody()->getContents();` we didn't reset the stream pointer before reading the string.

Now downstream consumers can read the stream without resetting after, and `parseJson()` continues to work.

- `(string) $this->response->getBody()` calls Guzzle stream `__toString()`.
- For seekable streams, `__toString()` rewinds to start before reading, so it still returns full JSON even if downstream consumed the stream earlier.
