### PR TITLE
Add ApiResponse to return types on send

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "ultimed/integration",
     "description": "Integration Kit for Ultimed",
     "require": {
+        "php": "^8.2",
         "guzzlehttp/psr7": "^1.2|^2.0",
         "guzzlehttp/guzzle": "^6.1|^7.0",
         "nesbot/carbon": "^2.17|^3.0"

--- a/src/Ultimed/ApiClient.php
+++ b/src/Ultimed/ApiClient.php
@@ -4,13 +4,13 @@ use Exception;
 use GuzzleHttp\Client;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Ultimed\OAuth\ClientCredentials;
 use Ultimed\OAuth\AccessToken;
+use Ultimed\OAuth\ClientCredentials;
 use Ultimed\Requests\ApiRequest;
-use Ultimed\Requests\IncludesOAuthClientCredentials;
-use Ultimed\Requests\IncludesOAuthAccessToken;
 use Ultimed\Requests\Authentication as AuthenticationRequest;
-use Ultimed\Responses\Authentication as AuthenticationResponse;
+use Ultimed\Requests\IncludesOAuthAccessToken;
+use Ultimed\Requests\IncludesOAuthClientCredentials;
+use Ultimed\Responses\ApiResponse;
 
 class ApiClient extends Client
 {
@@ -38,7 +38,7 @@ class ApiClient extends Client
         $this->accessToken = $accessToken;
     }
 
-    public function send(RequestInterface $request, array $options = []): ResponseInterface
+    public function send(RequestInterface $request, array $options = []): ResponseInterface | ApiResponse
     {
         $request = $this->prepareRequest($request);
 
@@ -70,7 +70,7 @@ class ApiClient extends Client
 
     private function convertResponse(
         RequestInterface $request,
-        ResponseInterface $response)
+        ResponseInterface $response): ResponseInterface | ApiResponse
     {
         $response = $this->wrapResponseInCustomClass($request, $response);
 
@@ -83,7 +83,7 @@ class ApiClient extends Client
 
     private function wrapResponseInCustomClass(
         RequestInterface $request,
-        ResponseInterface $response)
+        ResponseInterface $response): ResponseInterface | ApiResponse
     {
         if ($request instanceof ApiRequest) {
             $responseClass = str_replace('Request', 'Response', get_class($request));


### PR DESCRIPTION
This will avoid highlighting of calls to ApiResponse specific functions in hub as error, e.g. `isSuccessful`:

<img width="639" height="222" alt="image" src="https://github.com/user-attachments/assets/54677b4e-5c6c-4d0a-ab60-5705269b1481" />

The use-sorting happened on save, seems like this repo doesnt use php-cs-fixer.